### PR TITLE
Change how "list_reminder" is displayed

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddReminderCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddReminderCommand.java
@@ -11,13 +11,13 @@ import seedu.address.model.reminder.Reminder;
 /**
  * Adds a reminder to the address book.
  */
-public class AddReminder extends Command {
+public class AddReminderCommand extends Command {
 
     public static final String COMMAND_WORD = "add_reminder";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a reminder.\n"
             + "Parameters: "
-            + PREFIX_DESCRIPTION + "Description "
+            + PREFIX_DESCRIPTION + "DESCRIPTION "
             + PREFIX_TIME + "YYYY-MM-DD HH:MM";
 
     public static final String MESSAGE_SUCCESS = "New reminder added";
@@ -25,9 +25,9 @@ public class AddReminder extends Command {
     private final Reminder toAdd;
 
     /**
-     * Creates an AddReminder to add the specified {@code Reminder}
+     * Creates an AddReminderCommand to add the specified {@code Reminder}
      */
-    public AddReminder(Reminder reminder) {
+    public AddReminderCommand(Reminder reminder) {
         requireNonNull(reminder);
         toAdd = reminder;
     }
@@ -42,7 +42,7 @@ public class AddReminder extends Command {
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
-                || (other instanceof AddReminder // instanceof handles nulls
-                && toAdd.equals(((AddReminder) other).toAdd));
+                || (other instanceof AddReminderCommand // instanceof handles nulls
+                && toAdd.equals(((AddReminderCommand) other).toAdd));
     }
 }

--- a/src/main/java/seedu/address/logic/commands/CommandResult.java
+++ b/src/main/java/seedu/address/logic/commands/CommandResult.java
@@ -22,6 +22,11 @@ public class CommandResult {
     private final boolean showTimetable;
 
     /**
+     * Reminder list should be shown to the user.
+     */
+    private final boolean showReminderList;
+
+    /**
      * The application should exit.
      */
     private final boolean exit;
@@ -29,10 +34,12 @@ public class CommandResult {
     /**
      * Constructs a {@code CommandResult} with the specified fields.
      */
-    public CommandResult(String feedbackToUser, boolean showHelp, boolean showTimetable, boolean exit) {
+    public CommandResult(String feedbackToUser, boolean showHelp, boolean showTimetable, boolean showReminderList,
+                         boolean exit) {
         this.feedbackToUser = requireNonNull(feedbackToUser);
         this.showHelp = showHelp;
         this.showTimetable = showTimetable;
+        this.showReminderList = showReminderList;
         this.exit = exit;
     }
 
@@ -41,7 +48,7 @@ public class CommandResult {
      * and other fields set to their default value.
      */
     public CommandResult(String feedbackToUser) {
-        this(feedbackToUser, false, false, false);
+        this(feedbackToUser, false, false, false, false);
     }
 
     public String getFeedbackToUser() {
@@ -54,6 +61,10 @@ public class CommandResult {
 
     public boolean isShowTimetable() {
         return showTimetable;
+    }
+
+    public boolean isShowReminderList() {
+        return showReminderList;
     }
 
     public boolean isExit() {
@@ -75,12 +86,13 @@ public class CommandResult {
         return feedbackToUser.equals(otherCommandResult.feedbackToUser)
                 && showHelp == otherCommandResult.showHelp
                 && showTimetable == otherCommandResult.showTimetable
+                && showReminderList == otherCommandResult.showReminderList
                 && exit == otherCommandResult.exit;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(feedbackToUser, showHelp, showTimetable, exit);
+        return Objects.hash(feedbackToUser, showHelp, showTimetable, showReminderList, exit);
     }
 
 }

--- a/src/main/java/seedu/address/logic/commands/DeleteReminderCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteReminderCommand.java
@@ -12,7 +12,7 @@ import seedu.address.model.reminder.Reminder;
 /**
  * Deletes a reminder using it's displayed index from notifications.
  */
-public class DeleteReminder extends Command {
+public class DeleteReminderCommand extends Command {
     public static final String COMMAND_WORD = "delete_reminder";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
@@ -24,7 +24,7 @@ public class DeleteReminder extends Command {
 
     private final int targetIndex;
 
-    public DeleteReminder(int targetIndex) {
+    public DeleteReminderCommand(int targetIndex) {
         this.targetIndex = targetIndex - 1;
     }
 

--- a/src/main/java/seedu/address/logic/commands/ExitCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ExitCommand.java
@@ -13,7 +13,7 @@ public class ExitCommand extends Command {
 
     @Override
     public CommandResult execute(Model model) {
-        return new CommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT, false, false, true);
+        return new CommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT, false, false, false, true);
     }
 
 }

--- a/src/main/java/seedu/address/logic/commands/HelpCommand.java
+++ b/src/main/java/seedu/address/logic/commands/HelpCommand.java
@@ -16,6 +16,6 @@ public class HelpCommand extends Command {
 
     @Override
     public CommandResult execute(Model model) {
-        return new CommandResult(SHOWING_HELP_MESSAGE, true, false, false);
+        return new CommandResult(SHOWING_HELP_MESSAGE, true, false, false, false);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/ListReminderCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListReminderCommand.java
@@ -3,25 +3,21 @@ package seedu.address.logic.commands;
 import static java.util.Objects.requireNonNull;
 
 import seedu.address.model.Model;
-import seedu.address.ui.NotificationManager;
 
 /**
  * Lists all reminders as Notifications to the user.
  */
-public class ListReminder extends Command {
+public class ListReminderCommand extends Command {
 
     public static final String COMMAND_WORD = "list_reminder";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Lists all reminders.\n";
-
-    public static final String MESSAGE_SUCCESS = "Listed all reminders";
+    public static final String SHOWING_REMINDERLIST_MESSAGE = "Opened reminder list window.";
 
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
-        model.getReminderList();
-        NotificationManager notification = new NotificationManager(model);
-        notification.listReminders();
-        return new CommandResult(MESSAGE_SUCCESS);
+        return new CommandResult(SHOWING_REMINDERLIST_MESSAGE,
+                false, false, true, false);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/TimetableCommand.java
+++ b/src/main/java/seedu/address/logic/commands/TimetableCommand.java
@@ -28,7 +28,7 @@ public class TimetableCommand extends Command {
         model.updateSortedDeliveryJobList(SORTER);
         model.getSortedDeliveryJobList();
 
-        return new CommandResult(SHOWING_TIMETABLE_MESSAGE, false, true, false);
+        return new CommandResult(SHOWING_TIMETABLE_MESSAGE, false, true, false, false);
     }
 
 }

--- a/src/main/java/seedu/address/logic/parser/AddReminderParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddReminderParser.java
@@ -9,14 +9,14 @@ import java.time.format.DateTimeParseException;
 import java.util.stream.Stream;
 
 import seedu.address.commons.util.DateTimeUtil;
-import seedu.address.logic.commands.AddReminder;
+import seedu.address.logic.commands.AddReminderCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.reminder.Reminder;
 
 /**
- * Parses input arguments and creates a new AddReminder object
+ * Parses input arguments and creates a new AddReminderCommand object
  */
-public class AddReminderParser implements Parser<AddReminder> {
+public class AddReminderParser implements Parser<AddReminderCommand> {
 
     /**
      * Returns true if none of the prefixes contains empty {@code Optional} values in the given
@@ -27,19 +27,19 @@ public class AddReminderParser implements Parser<AddReminder> {
     }
 
     /**
-     * Parses the given {@code String} of arguments in the context of the AddReminder
-     * and returns an AddReminder object for execution.
+     * Parses the given {@code String} of arguments in the context of the AddReminderCommand
+     * and returns an AddReminderCommand object for execution.
      *
      * @throws ParseException if the user input does not conform the expected format
      */
     @Override
-    public AddReminder parse(String args) throws ParseException {
+    public AddReminderCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_DESCRIPTION, PREFIX_TIME);
 
         if (!arePrefixesPresent(argMultimap, PREFIX_DESCRIPTION, PREFIX_TIME)
                 || !argMultimap.getPreamble().isEmpty()) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddReminder.MESSAGE_USAGE));
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddReminderCommand.MESSAGE_USAGE));
         }
 
         String description = argMultimap.getValue(PREFIX_DESCRIPTION).orElse("");
@@ -48,11 +48,11 @@ public class AddReminderParser implements Parser<AddReminder> {
         try {
             dateTime = DateTimeUtil.toDateTime(dateTimeString);
         } catch (DateTimeParseException e) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddReminder.MESSAGE_USAGE));
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddReminderCommand.MESSAGE_USAGE));
         }
 
         Reminder reminder = new Reminder(description, dateTime);
 
-        return new AddReminder(reminder);
+        return new AddReminderCommand(reminder);
     }
 }

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -7,17 +7,17 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import seedu.address.logic.commands.AddCommand;
-import seedu.address.logic.commands.AddReminder;
+import seedu.address.logic.commands.AddReminderCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.DeleteCommand;
-import seedu.address.logic.commands.DeleteReminder;
+import seedu.address.logic.commands.DeleteReminderCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
-import seedu.address.logic.commands.ListReminder;
+import seedu.address.logic.commands.ListReminderCommand;
 import seedu.address.logic.commands.TimetableCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
@@ -72,13 +72,13 @@ public class AddressBookParser {
         case HelpCommand.COMMAND_WORD:
             return new HelpCommand();
 
-        case AddReminder.COMMAND_WORD:
+        case AddReminderCommand.COMMAND_WORD:
             return new AddReminderParser().parse(arguments);
 
-        case ListReminder.COMMAND_WORD:
-            return new ListReminder();
+        case ListReminderCommand.COMMAND_WORD:
+            return new ListReminderCommand();
 
-        case DeleteReminder.COMMAND_WORD:
+        case DeleteReminderCommand.COMMAND_WORD:
             return new DeleteReminderParser().parse(arguments);
 
         case TimetableCommand.COMMAND_WORD:

--- a/src/main/java/seedu/address/logic/parser/DeleteReminderParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteReminderParser.java
@@ -2,20 +2,20 @@ package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
-import seedu.address.logic.commands.DeleteReminder;
+import seedu.address.logic.commands.DeleteReminderCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
- * Parses input arguments and creates a new DeleteReminder object
+ * Parses input arguments and creates a new DeleteReminderCommand object
  */
-public class DeleteReminderParser implements Parser<DeleteReminder> {
+public class DeleteReminderParser implements Parser<DeleteReminderCommand> {
     @Override
-    public DeleteReminder parse(String args) throws ParseException {
+    public DeleteReminderCommand parse(String args) throws ParseException {
         try {
-            return new DeleteReminder(Integer.parseInt(args.trim()));
+            return new DeleteReminderCommand(Integer.parseInt(args.trim()));
         } catch (NumberFormatException e) {
             throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteReminder.MESSAGE_USAGE), e);
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteReminderCommand.MESSAGE_USAGE), e);
         }
     }
 }

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -41,6 +41,7 @@ public class MainWindow extends UiPart<Stage> {
     private ResultDisplay resultDisplay;
     private HelpWindow helpWindow;
     private TimetableWindow timetableWindow;
+    private ReminderListWindow reminderListWindow;
     private StatisticsWindow statsWindow;
 
     @FXML
@@ -54,7 +55,8 @@ public class MainWindow extends UiPart<Stage> {
 
     @FXML
     private MenuItem timetableMenuItem;
-
+    @FXML
+    private MenuItem reminderListMenuItem;
     @FXML
     private MenuItem statsItem;
 
@@ -87,6 +89,7 @@ public class MainWindow extends UiPart<Stage> {
 
         helpWindow = new HelpWindow();
         timetableWindow = new TimetableWindow(new Stage(), logic);
+        reminderListWindow = new ReminderListWindow(new Stage(), logic);
         statsWindow = new StatisticsWindow(new Stage(), logic);
     }
 
@@ -193,6 +196,19 @@ public class MainWindow extends UiPart<Stage> {
         }
     }
 
+    /**
+     * Opens Reminder List window.
+     */
+    @FXML
+    private void handleReminderList() {
+        if (!reminderListWindow.isShowing()) {
+            reminderListWindow.show();
+            reminderListWindow.fillInnerParts();
+        } else {
+            reminderListWindow.focus();
+        }
+    }
+
     void show() {
         primaryStage.show();
     }
@@ -249,6 +265,10 @@ public class MainWindow extends UiPart<Stage> {
 
             if (commandResult.isShowTimetable()) {
                 handleTimetable();
+            }
+
+            if (commandResult.isShowReminderList()) {
+                handleReminderList();
             }
 
             if (commandResult.isExit()) {

--- a/src/main/java/seedu/address/ui/ReminderListWindow.java
+++ b/src/main/java/seedu/address/ui/ReminderListWindow.java
@@ -1,0 +1,102 @@
+package seedu.address.ui;
+
+import java.util.logging.Logger;
+
+import javafx.fxml.FXML;
+import javafx.scene.Scene;
+import javafx.scene.control.ListCell;
+import javafx.scene.control.ListView;
+import javafx.stage.Stage;
+import seedu.address.commons.core.LogsCenter;
+import seedu.address.logic.Logic;
+import seedu.address.model.reminder.Reminder;
+
+/**
+ * The reminder list Window. Displays all the reminders that have been added so far.
+ */
+public class ReminderListWindow extends UiPart<Stage> {
+    private static final String FXML = "ReminderListWindow.fxml";
+    private final Logger logger = LogsCenter.getLogger(getClass());
+    private Logic logic;
+    private Stage stage;
+    @FXML
+    private ListView<Reminder> reminderList;
+
+    /**
+     * Creates a new ReminderListWindow.
+     *
+     * @param logic Stores the reminder list.
+     */
+    public ReminderListWindow(Stage root, Logic logic) {
+        super(FXML, root);
+        // Set dependencies
+        this.stage = root;
+        this.logic = logic;
+        reminderList = new ListView<>(logic.getReminderList());
+    }
+
+    /**
+     * Shows the help window.
+     * @throws IllegalStateException
+     *     <ul>
+     *         <li>
+     *             if this method is called on a thread other than the JavaFX Application Thread.
+     *         </li>
+     *         <li>
+     *             if this method is called during animation or layout processing.
+     *         </li>
+     *         <li>
+     *             if this method is called on the primary stage.
+     *         </li>
+     *         <li>
+     *             if {@code dialogStage} is already showing.
+     *         </li>
+     *     </ul>
+     */
+    public void show() {
+        logger.fine("Showing reminder list window.");
+        getRoot().show();
+        getRoot().centerOnScreen();
+    }
+
+    /**
+     * Returns true if the reminder list window is currently being shown.
+     */
+    public boolean isShowing() {
+        return getRoot().isShowing();
+    }
+
+    /**
+     * Hides the reminder list window.
+     */
+    public void hide() {
+        getRoot().hide();
+    }
+
+    /**
+     * Focuses on the reminder list window.
+     */
+    public void focus() {
+        getRoot().requestFocus();
+    }
+
+    /**
+     * Fills up all the placeholders of this window.
+     */
+    void fillInnerParts() {
+        reminderList.setCellFactory(param -> new ListCell<>() {
+            @Override
+            protected void updateItem(Reminder item, boolean empty) {
+                super.updateItem(item, empty);
+                int i = super.getIndex() + 1;
+                if (empty || item == null) {
+                    setText(null);
+                } else {
+                    setText(i + ". " + item.getDescription() + " " + item.reminderDateTimeToString());
+                }
+            }
+        });
+        stage.setScene(new Scene(reminderList));
+        stage.show();
+    }
+}

--- a/src/main/java/seedu/address/ui/TimetableWindow.java
+++ b/src/main/java/seedu/address/ui/TimetableWindow.java
@@ -26,7 +26,6 @@ public class TimetableWindow extends UiPart<Stage> {
     private Logic logic;
 
     // Independent Ui parts residing in this Ui container
-    //private jobListPanel jobListPanel;
     private ResultDisplay resultDisplay;
     @FXML
     private StackPane commandBoxPlaceholder;
@@ -38,7 +37,7 @@ public class TimetableWindow extends UiPart<Stage> {
     private StackPane statusbarPlaceholder;
 
     /**
-     * Creates a {@code JobWindow} with the given {@code Stage} and {@code Logic}.
+     * Creates a {@code TimeTableWindow} with the given {@code Stage} and {@code Logic}.
      */
     public TimetableWindow(Stage primaryStage, Logic logic) {
         super(FXML, primaryStage);
@@ -76,21 +75,21 @@ public class TimetableWindow extends UiPart<Stage> {
     }
 
     /**
-     * Returns true if the job window is currently being shown.
+     * Returns true if the timetable window is currently being shown.
      */
     public boolean isShowing() {
         return getRoot().isShowing();
     }
 
     /**
-     * Hides the job window.
+     * Hides the timetable window.
      */
     public void hide() {
         getRoot().hide();
     }
 
     /**
-     * Focuses on the job window.
+     * Focuses on the timetable window.
      */
     public void focus() {
         getRoot().requestFocus();

--- a/src/main/resources/view/ReminderListWindow.fxml
+++ b/src/main/resources/view/ReminderListWindow.fxml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import java.net.URL?>
+<?import javafx.geometry.Insets?>
+<?import javafx.scene.Scene?>
+<?import javafx.scene.control.ListView?>
+<?import javafx.scene.layout.HBox?>
+<?import javafx.stage.Stage?>
+
+<fx:root resizable="false" title="Reminder List" type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/19" xmlns:fx="http://javafx.com/fxml/1">
+  <scene>
+    <Scene>
+      <stylesheets>
+        <URL value="@HelpWindow.css" />
+      </stylesheets>
+
+      <HBox fx:id="reminderListContainer" alignment="CENTER">
+        <children>
+               <ListView prefHeight="200.0" prefWidth="200.0" />
+        </children>
+        <opaqueInsets>
+          <Insets bottom="10.0" left="5.0" right="10.0" top="5.0" />
+        </opaqueInsets>
+        <padding>
+          <Insets bottom="10.0" left="5.0" right="10.0" top="5.0" />
+        </padding>
+      </HBox>
+    </Scene>
+  </scene>
+</fx:root>

--- a/src/test/java/seedu/address/logic/commands/CommandResultTest.java
+++ b/src/test/java/seedu/address/logic/commands/CommandResultTest.java
@@ -14,7 +14,7 @@ public class CommandResultTest {
 
         // same values -> returns true
         assertTrue(commandResult.equals(new CommandResult("feedback")));
-        assertTrue(commandResult.equals(new CommandResult("feedback", false, false, false)));
+        assertTrue(commandResult.equals(new CommandResult("feedback", false, false, false, false)));
 
         // same object -> returns true
         assertTrue(commandResult.equals(commandResult));
@@ -29,13 +29,16 @@ public class CommandResultTest {
         assertFalse(commandResult.equals(new CommandResult("different")));
 
         // different showHelp value -> returns false
-        assertFalse(commandResult.equals(new CommandResult("feedback", true, false, false)));
+        assertFalse(commandResult.equals(new CommandResult("feedback", true, false, false, false)));
 
         // different showTimetable value -> returns false
-        assertFalse(commandResult.equals(new CommandResult("feedback", false, true, false)));
+        assertFalse(commandResult.equals(new CommandResult("feedback", false, true, false, false)));
+
+        // different showReminderList value -> returns false
+        assertFalse(commandResult.equals(new CommandResult("feedback", false, true, true, false)));
 
         // different exit value -> returns false
-        assertFalse(commandResult.equals(new CommandResult("feedback", false, false, true)));
+        assertFalse(commandResult.equals(new CommandResult("feedback", false, false, false, true)));
     }
 
     @Test
@@ -49,12 +52,12 @@ public class CommandResultTest {
         assertNotEquals(commandResult.hashCode(), new CommandResult("different").hashCode());
 
         // different showHelp value -> returns different hashcode
-        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", true, false, false).hashCode());
+        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", true, false, false, false).hashCode());
 
         // different showTimetable value -> returns different hashcode
-        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", false, true, false).hashCode());
+        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", false, true, false, false).hashCode());
 
         // different exit value -> returns different hashcode
-        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", false, false, true).hashCode());
+        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", false, false, false, true).hashCode());
     }
 }

--- a/src/test/java/seedu/address/logic/commands/ExitCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ExitCommandTest.java
@@ -14,7 +14,8 @@ public class ExitCommandTest {
 
     @Test
     public void execute_exit_success() {
-        CommandResult expectedCommandResult = new CommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT, false, false, true);
+        CommandResult expectedCommandResult = new CommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT, false,
+                false, false, true);
         assertCommandSuccess(new ExitCommand(), model, expectedCommandResult, expectedModel);
     }
 }

--- a/src/test/java/seedu/address/logic/commands/HelpCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/HelpCommandTest.java
@@ -14,7 +14,7 @@ public class HelpCommandTest {
 
     @Test
     public void execute_help_success() {
-        CommandResult expectedCommandResult = new CommandResult(SHOWING_HELP_MESSAGE, true, false, false);
+        CommandResult expectedCommandResult = new CommandResult(SHOWING_HELP_MESSAGE, true, false, false, false);
         assertCommandSuccess(new HelpCommand(), model, expectedCommandResult, expectedModel);
     }
 }


### PR DESCRIPTION
Previous version of the command would show all the reminders as notification on the screen. This would bloat the screen if there was a lot of reminders in the app.

Let's:
* create a new window to display all the reminders when the "list_reminder" is called

Also:
* renamed all reminder related classes in logic.commands by ending it off with "command"
* corrected comments in timetable classes