### PR TITLE
Add delete button and command group filtering for logic

### DIFF
--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -19,5 +19,6 @@ public class Messages {
     public static final String MESSAGE_INVALID_JOB_ID = "The job id provided is invalid";
     public static final String MESSAGE_INVALID_JOB_DISPLAYED_INDEX = "The job index provided is invalid";
     public static final String MESSAGE_DELIVERY_JOB_LISTED_OVERVIEW = "%1$d jobs listed!";
+    public static final String COMMAND_NOT_ALLOW = "Command not allowed!";
 
 }

--- a/src/main/java/seedu/address/logic/Logic.java
+++ b/src/main/java/seedu/address/logic/Logic.java
@@ -10,6 +10,7 @@ import java.util.function.Predicate;
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.logic.commands.Command;
+import seedu.address.logic.commands.CommandGroup;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -33,6 +34,18 @@ public interface Logic {
      * @throws ParseException   If an error occurs during parsing.
      */
     CommandResult execute(String commandText) throws CommandException, ParseException, FileNotFoundException;
+
+    /**
+     * Executes the command for chosen group and returns the result.
+     *
+     * @param commandText The command as entered by the user.
+     * @param condition execute when true.
+     * @return the result of the command execution.
+     * @throws CommandException If an error occurs during command execution.
+     * @throws ParseException   If an error occurs during parsing.
+     */
+    CommandResult execute(String commandText, Predicate<CommandGroup> condition)
+            throws CommandException, ParseException, FileNotFoundException;
 
     /**
      * Executes specific command object and returns the result.

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -13,7 +13,9 @@ import java.util.logging.Logger;
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
+import seedu.address.commons.core.Messages;
 import seedu.address.logic.commands.Command;
+import seedu.address.logic.commands.CommandGroup;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.DukeDriverParser;
@@ -61,6 +63,19 @@ public class LogicManager implements Logic {
 
         Command command = addressBookParser.parseCommand(commandText);
         return execute(command);
+    }
+
+    @Override
+    public CommandResult execute(String commandText, Predicate<CommandGroup> condition)
+            throws CommandException, ParseException, FileNotFoundException {
+        logger.info("----------------[USER COMMAND][" + commandText + "]");
+
+        Command command = addressBookParser.parseCommand(commandText);
+        if (condition.test(command.getGroup())) {
+            return execute(command);
+        } else {
+            return new CommandResult(String.format(Messages.COMMAND_NOT_ALLOW));
+        }
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/Command.java
+++ b/src/main/java/seedu/address/logic/commands/Command.java
@@ -21,4 +21,12 @@ public abstract class Command {
      */
     public abstract CommandResult execute(Model model) throws CommandException, ParseException, FileNotFoundException;
 
+    /**
+     * Returns the group of command.
+     *
+     * @return CommandGroup
+     */
+    public CommandGroup getGroup() {
+        return CommandGroup.GENERAL;
+    }
 }

--- a/src/main/java/seedu/address/logic/commands/CommandGroup.java
+++ b/src/main/java/seedu/address/logic/commands/CommandGroup.java
@@ -1,0 +1,11 @@
+package seedu.address.logic.commands;
+
+/**
+ * Groups commands types.
+ */
+public enum CommandGroup {
+    GENERAL,
+    PERSON,
+    TIMETABLE,
+    JOB
+}

--- a/src/main/java/seedu/address/logic/commands/jobs/AddDeliveryJobCommand.java
+++ b/src/main/java/seedu/address/logic/commands/jobs/AddDeliveryJobCommand.java
@@ -7,7 +7,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_EARNING;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_RECIPIENT_ID;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_SENDER_ID;
 
-import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
@@ -16,7 +15,7 @@ import seedu.address.model.jobs.DeliveryJob;
 /**
  * Adds a delivery job to the delivery job system.
  */
-public class AddDeliveryJobCommand extends Command {
+public class AddDeliveryJobCommand extends DeliveryJobCommand {
 
     public static final String COMMAND_WORD = "add_job";
 

--- a/src/main/java/seedu/address/logic/commands/jobs/CompleteDeliveryJobCommand.java
+++ b/src/main/java/seedu/address/logic/commands/jobs/CompleteDeliveryJobCommand.java
@@ -6,7 +6,6 @@ import java.util.List;
 import java.util.Optional;
 
 import seedu.address.commons.core.Messages;
-import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.model.Model;
 import seedu.address.model.jobs.DeliveryJob;
@@ -14,7 +13,7 @@ import seedu.address.model.jobs.DeliveryJob;
 /**
  * Sets delivered status for jobs in the delivery job system.
  */
-public class CompleteDeliveryJobCommand extends Command {
+public class CompleteDeliveryJobCommand extends DeliveryJobCommand {
 
     public static final String COMMAND_WORD_MARK = "com_job";
     public static final String COMMAND_WORD_UNMARK = "uncom_job";

--- a/src/main/java/seedu/address/logic/commands/jobs/DeleteDeliveryJobCommand.java
+++ b/src/main/java/seedu/address/logic/commands/jobs/DeleteDeliveryJobCommand.java
@@ -6,7 +6,6 @@ import java.util.List;
 import java.util.Optional;
 
 import seedu.address.commons.core.Messages;
-import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
@@ -15,7 +14,7 @@ import seedu.address.model.jobs.DeliveryJob;
 /**
  * Deletes a job identified using it's displayed index from the job system.
  */
-public class DeleteDeliveryJobCommand extends Command {
+public class DeleteDeliveryJobCommand extends DeliveryJobCommand {
 
     public static final String COMMAND_WORD = "delete_job";
 

--- a/src/main/java/seedu/address/logic/commands/jobs/DeliveryJobCommand.java
+++ b/src/main/java/seedu/address/logic/commands/jobs/DeliveryJobCommand.java
@@ -1,0 +1,14 @@
+package seedu.address.logic.commands.jobs;
+
+import seedu.address.logic.commands.Command;
+import seedu.address.logic.commands.CommandGroup;
+
+/**
+ * Defines PersonCommand.
+ */
+abstract class DeliveryJobCommand extends Command {
+    @Override
+    public CommandGroup getGroup() {
+        return CommandGroup.JOB;
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/jobs/EditDeliveryJobCommand.java
+++ b/src/main/java/seedu/address/logic/commands/jobs/EditDeliveryJobCommand.java
@@ -16,7 +16,6 @@ import java.util.Optional;
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.CollectionUtil;
-import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
@@ -28,7 +27,7 @@ import seedu.address.model.jobs.Earning;
 /**
  * Edits the details of an existing job in the job system.
  */
-public class EditDeliveryJobCommand extends Command {
+public class EditDeliveryJobCommand extends DeliveryJobCommand {
 
     public static final String COMMAND_WORD = "edit_job";
 

--- a/src/main/java/seedu/address/logic/commands/jobs/FindDeliveryJobCommand.java
+++ b/src/main/java/seedu/address/logic/commands/jobs/FindDeliveryJobCommand.java
@@ -5,7 +5,6 @@ import static java.util.Objects.requireNonNull;
 import java.util.function.Predicate;
 
 import seedu.address.commons.core.Messages;
-import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.model.Model;
 import seedu.address.model.jobs.DeliveryJob;
@@ -14,7 +13,7 @@ import seedu.address.model.jobs.DeliveryJob;
  * Finds and lists all jobs in job system whose name contains any of the argument keywords.
  * Keyword matching is case insensitive.
  */
-public class FindDeliveryJobCommand extends Command {
+public class FindDeliveryJobCommand extends DeliveryJobCommand {
 
     public static final String COMMAND_WORD = "find_job";
 

--- a/src/main/java/seedu/address/logic/commands/jobs/ImportDeliveryJobCommand.java
+++ b/src/main/java/seedu/address/logic/commands/jobs/ImportDeliveryJobCommand.java
@@ -6,7 +6,6 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.util.List;
 
-import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -17,7 +16,7 @@ import seedu.address.model.jobs.DeliveryJob;
 /**
  * Mass imports delivery jobs from CSV file to the delivery job system.
  */
-public class ImportDeliveryJobCommand extends Command {
+public class ImportDeliveryJobCommand extends DeliveryJobCommand {
 
     public static final String COMMAND_WORD = "import_job";
     public static final String MESSAGE_EMPTY_FILE = "File is empty";

--- a/src/main/java/seedu/address/logic/commands/jobs/ListDeliveryJobCommand.java
+++ b/src/main/java/seedu/address/logic/commands/jobs/ListDeliveryJobCommand.java
@@ -3,14 +3,13 @@ package seedu.address.logic.commands.jobs;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_DELIVERY_JOBS;
 
-import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.model.Model;
 
 /**
  * Lists all jobs in the delivery job system to the user.
  */
-public class ListDeliveryJobCommand extends Command {
+public class ListDeliveryJobCommand extends DeliveryJobCommand {
 
     public static final String COMMAND_WORD = "list_job";
 

--- a/src/main/java/seedu/address/logic/commands/person/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/person/AddCommand.java
@@ -7,7 +7,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
-import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
@@ -17,7 +16,7 @@ import seedu.address.model.person.Person;
 /**
  * Adds a person to the address book.
  */
-public class AddCommand extends Command {
+public class AddCommand extends PersonCommand {
 
     public static final String COMMAND_WORD = "add";
 

--- a/src/main/java/seedu/address/logic/commands/person/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/person/DeleteCommand.java
@@ -6,7 +6,6 @@ import java.util.List;
 
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
-import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
@@ -15,7 +14,7 @@ import seedu.address.model.person.Person;
 /**
  * Deletes a person identified using it's displayed index from the address book.
  */
-public class DeleteCommand extends Command {
+public class DeleteCommand extends PersonCommand {
 
     public static final String COMMAND_WORD = "delete";
 

--- a/src/main/java/seedu/address/logic/commands/person/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/person/EditCommand.java
@@ -17,7 +17,6 @@ import java.util.Set;
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.CollectionUtil;
-import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
@@ -31,7 +30,7 @@ import seedu.address.model.tag.Tag;
 /**
  * Edits the details of an existing person in the address book.
  */
-public class EditCommand extends Command {
+public class EditCommand extends PersonCommand {
 
     public static final String COMMAND_WORD = "edit";
 

--- a/src/main/java/seedu/address/logic/commands/person/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/person/FindCommand.java
@@ -3,7 +3,6 @@ package seedu.address.logic.commands.person;
 import static java.util.Objects.requireNonNull;
 
 import seedu.address.commons.core.Messages;
-import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.model.Model;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
@@ -12,7 +11,7 @@ import seedu.address.model.person.NameContainsKeywordsPredicate;
  * Finds and lists all persons in address book whose name contains any of the argument keywords.
  * Keyword matching is case insensitive.
  */
-public class FindCommand extends Command {
+public class FindCommand extends PersonCommand {
 
     public static final String COMMAND_WORD = "find";
 

--- a/src/main/java/seedu/address/logic/commands/person/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/person/ListCommand.java
@@ -3,14 +3,14 @@ package seedu.address.logic.commands.person;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
-import seedu.address.logic.commands.Command;
+import seedu.address.logic.commands.CommandGroup;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.model.Model;
 
 /**
  * Lists all persons in the address book to the user.
  */
-public class ListCommand extends Command {
+public class ListCommand extends PersonCommand {
 
     public static final String COMMAND_WORD = "list";
 
@@ -22,5 +22,10 @@ public class ListCommand extends Command {
         requireNonNull(model);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
         return new CommandResult(MESSAGE_SUCCESS, false, false, false, false, false, false, true, false, false);
+    }
+
+    @Override
+    public CommandGroup getGroup() {
+        return CommandGroup.GENERAL;
     }
 }

--- a/src/main/java/seedu/address/logic/commands/person/PersonCommand.java
+++ b/src/main/java/seedu/address/logic/commands/person/PersonCommand.java
@@ -1,0 +1,14 @@
+package seedu.address.logic.commands.person;
+
+import seedu.address.logic.commands.Command;
+import seedu.address.logic.commands.CommandGroup;
+
+/**
+ * Defines PersonCommand.
+ */
+abstract class PersonCommand extends Command {
+    @Override
+    public CommandGroup getGroup() {
+        return CommandGroup.PERSON;
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/jobs/ImportDeliveryJobCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/jobs/ImportDeliveryJobCommandParser.java
@@ -26,30 +26,31 @@ public class ImportDeliveryJobCommandParser {
      */
     public static List<DeliveryJob> parse(File file) throws ParseException, FileNotFoundException {
 
-        Scanner sc = new Scanner(file);
-        List<DeliveryJob> listOfAddDeliveryJob = new ArrayList<>();
+        try (Scanner sc = new Scanner(file)) {
+            List<DeliveryJob> listOfAddDeliveryJob = new ArrayList<>();
 
-        while (sc.hasNextLine()) {
-            String line = sc.nextLine();
-            String[] arrOfStr = line.split(",");
+            while (sc.hasNextLine()) {
+                String line = sc.nextLine();
+                String[] arrOfStr = line.split(",");
 
-            if (arrOfStr.length != 5) {
-                throw new ParseException(
-                        String.format(MESSAGE_MISSING_ELEMENT_IN_IMPORT, AddDeliveryJobCommand.MESSAGE_USAGE));
+                if (arrOfStr.length != 5) {
+                    throw new ParseException(
+                            String.format(MESSAGE_MISSING_ELEMENT_IN_IMPORT, AddDeliveryJobCommand.MESSAGE_USAGE));
+                }
+
+                String sid = arrOfStr[0];
+                String rid = arrOfStr[1];
+                String ded = arrOfStr[2];
+                String des = arrOfStr[3];
+                String ear = arrOfStr[4];
+
+                DeliveryJob job = new DeliveryJob(rid, sid, ded, des, ear, "");
+
+                listOfAddDeliveryJob.add(job);
             }
-
-            String sid = arrOfStr[0];
-            String rid = arrOfStr[1];
-            String ded = arrOfStr[2];
-            String des = arrOfStr[3];
-            String ear = arrOfStr[4];
-
-            DeliveryJob job = new DeliveryJob(rid, sid, ded, des, ear, "");
-
-            listOfAddDeliveryJob.add(job);
+            sc.close();
+            return listOfAddDeliveryJob;
         }
-
-        return listOfAddDeliveryJob;
     }
 }
 

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -21,6 +21,7 @@ import javafx.stage.Stage;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.logic.Logic;
+import seedu.address.logic.commands.CommandGroup;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.commands.jobs.CompleteDeliveryJobCommand;
@@ -518,7 +519,7 @@ public class MainWindow extends UiPart<Stage> {
     private CommandResult executeCommand(String commandText)
             throws CommandException, ParseException, FileNotFoundException {
         try {
-            CommandResult commandResult = logic.execute(commandText);
+            CommandResult commandResult = logic.execute(commandText, g -> !g.equals(CommandGroup.PERSON));
             logger.info("Result: " + commandResult.getFeedbackToUser());
             resultDisplay.setFeedbackToUser(commandResult.getFeedbackToUser());
 

--- a/src/main/java/seedu/address/ui/jobs/AddDeliveryJobWindow.java
+++ b/src/main/java/seedu/address/ui/jobs/AddDeliveryJobWindow.java
@@ -4,6 +4,7 @@ import java.io.FileNotFoundException;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.Optional;
+import java.util.function.Consumer;
 import java.util.function.UnaryOperator;
 import java.util.logging.Logger;
 
@@ -25,6 +26,7 @@ import javafx.stage.Stage;
 import javafx.util.StringConverter;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.logic.Logic;
+import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.commands.jobs.AddDeliveryJobCommand;
 import seedu.address.logic.commands.jobs.EditDeliveryJobCommand;
@@ -50,7 +52,7 @@ public class AddDeliveryJobWindow extends UiPart<Stage> {
 
     private Stage primaryStage;
     private Logic logic;
-    private Runnable completeEditCallback;
+    private Consumer<CommandResult> completeEditCallback;
     private AddressBookWindow addressBookWindow;
 
     @FXML
@@ -147,7 +149,7 @@ public class AddDeliveryJobWindow extends UiPart<Stage> {
     /**
      * Edit mode.
      */
-    public AddDeliveryJobWindow(Stage primaryStage, Logic logic, DeliveryJob job, Runnable callback) {
+    public AddDeliveryJobWindow(Stage primaryStage, Logic logic, DeliveryJob job, Consumer<CommandResult> callback) {
         super(FXML, primaryStage);
         this.primaryStage = primaryStage;
         this.logic = logic;
@@ -235,13 +237,12 @@ public class AddDeliveryJobWindow extends UiPart<Stage> {
 
         try {
             EditDeliveryJobCommand.EditDeliveryJobDescriptor des = prepareChange();
-            logic.execute(new EditDeliveryJobCommand(des));
-            completeEditCallback.run();
+            CommandResult commandResult = logic.execute(new EditDeliveryJobCommand(des));
+            completeEditCallback.accept(commandResult);
             getRoot().close();
-        } catch (ParseException | CommandException e) {
+        } catch (FileNotFoundException | ParseException | CommandException e) {
             logger.warning("[Event] editDeliveryJob" + e.getMessage());
-        } catch (FileNotFoundException e) {
-            logger.warning("[Event] editDeliveryJob" + e.getMessage());
+            outputError(e.getMessage());
         }
     }
 
@@ -259,15 +260,15 @@ public class AddDeliveryJobWindow extends UiPart<Stage> {
             if (inputDeliverySlot.getValue() == null) {
                 // if date and slot is empty
                 job = new DeliveryJob(
-                        inputSender.getText(),
                         inputRecipient.getText(),
+                        inputSender.getText(),
                         inputEarning.getText(),
                         inputDescription.getText());
             } else {
                 // if date and slot has value
                 job = new DeliveryJob(
-                        inputSender.getText(),
                         inputRecipient.getText(),
+                        inputSender.getText(),
                         inputDeliveryDate.getValue().toString(),
                         Integer.toString(inputDeliverySlot.getSelectionModel().getSelectedIndex()),
                         inputEarning.getText(),
@@ -276,10 +277,9 @@ public class AddDeliveryJobWindow extends UiPart<Stage> {
 
             logic.execute(new AddDeliveryJobCommand(job));
             getRoot().close();
-        } catch (ParseException | CommandException e) {
+        } catch (FileNotFoundException | ParseException | CommandException e) {
             logger.warning("[Event] createDeliveryJob" + e.getMessage());
-        } catch (FileNotFoundException e) {
-            logger.warning("[Event] createDeliveryJob" + e.getMessage());
+            outputError(e.getMessage());
         }
     }
 

--- a/src/main/java/seedu/address/ui/jobs/DeliveryJobDetailPane.java
+++ b/src/main/java/seedu/address/ui/jobs/DeliveryJobDetailPane.java
@@ -34,6 +34,7 @@ public class DeliveryJobDetailPane extends UiPart<Region> {
 
     private Consumer<DeliveryJob> handleEdit;
     private Consumer<DeliveryJob> handleComplete;
+    private Consumer<DeliveryJob> handleDelete;
 
     @FXML
     private StackPane senderContactInfoPlaceholder;
@@ -122,6 +123,7 @@ public class DeliveryJobDetailPane extends UiPart<Region> {
         description.setText(job.getDescription());
         handleEdit = (job) -> {};
         handleComplete = (job) -> {};
+        handleDelete = (job) -> {};
         updateCompleteButton();
     }
 
@@ -143,6 +145,15 @@ public class DeliveryJobDetailPane extends UiPart<Region> {
         handleComplete = handler;
     }
 
+    /**
+     * Sets the delete handler.
+     *
+     * @param handler
+     */
+    public void setDeleteHandler(Consumer<DeliveryJob> handler) {
+        handleDelete = handler;
+    }
+
     @FXML
     void handleEditAction() {
         logger.info("[Event] handleEditAction");
@@ -154,6 +165,12 @@ public class DeliveryJobDetailPane extends UiPart<Region> {
         logger.info("[Event] handleCompleteAction");
         updateCompleteButton();
         handleComplete.accept(job);
+    }
+
+    @FXML
+    void handleDeleteAction() {
+        logger.info("[Event] handleDeleteAction");
+        handleDelete.accept(job);
     }
 
     @FXML

--- a/src/main/java/seedu/address/ui/jobs/DeliveryJobListPanel.java
+++ b/src/main/java/seedu/address/ui/jobs/DeliveryJobListPanel.java
@@ -130,8 +130,14 @@ public class DeliveryJobListPanel extends UiPart<Region> {
     /**
      * selectPrevious.
      */
-    public void selectPrevious() {
-        deliveryJobListView.getSelectionModel().selectPrevious();
+    public void selectAvailable() {
+        if (this.size() > 0) {
+            if (deliveryJobListView.getSelectionModel().getSelectedIndex() != this.size() - 1) {
+                deliveryJobListView.getSelectionModel().selectNext();
+            } else {
+                deliveryJobListView.getSelectionModel().selectPrevious();
+            }
+        }
     }
 
     /**

--- a/src/main/java/seedu/address/ui/person/AddressBookWindow.java
+++ b/src/main/java/seedu/address/ui/person/AddressBookWindow.java
@@ -9,6 +9,7 @@ import javafx.scene.layout.StackPane;
 import javafx.stage.Stage;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.logic.Logic;
+import seedu.address.logic.commands.CommandGroup;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.commands.person.DeleteCommand;
@@ -25,11 +26,10 @@ import seedu.address.ui.main.StatusBarFooter;
  */
 public class AddressBookWindow extends UiPart<Stage> {
 
-    private static final String FXML = "AddressBookWIndow.fxml";
+    private static final String FXML = "AddressBookWindow.fxml";
 
     private final Logger logger = LogsCenter.getLogger(getClass());
     private final Consumer<Person> selectHandler;
-    private final MainWindow dukeDriverWindow;
 
     private Stage primaryStage;
     private Logic logic;
@@ -59,7 +59,6 @@ public class AddressBookWindow extends UiPart<Stage> {
      */
     public AddressBookWindow(Stage primaryStage, Logic logic, Consumer<Person> selectHandler) {
         super(FXML, primaryStage);
-        this.dukeDriverWindow = new MainWindow(primaryStage, logic);
 
         // Set dependencies
         this.primaryStage = primaryStage;
@@ -74,7 +73,6 @@ public class AddressBookWindow extends UiPart<Stage> {
     public AddressBookWindow(Stage primaryStage, Logic logic,
                              Consumer<Person> selectHandler, MainWindow dukeDriverWindow) {
         super(FXML, primaryStage);
-        this.dukeDriverWindow = dukeDriverWindow;
 
         // Set dependencies
         this.primaryStage = primaryStage;
@@ -144,10 +142,6 @@ public class AddressBookWindow extends UiPart<Stage> {
         primaryStage.hide();
     }
 
-    private void handleListJob() {
-        dukeDriverWindow.focus();
-    }
-
     /**
      * Executes the command and returns the result.
      *
@@ -156,16 +150,13 @@ public class AddressBookWindow extends UiPart<Stage> {
     private CommandResult executeCommand(String commandText)
             throws CommandException, ParseException, FileNotFoundException {
         try {
-            CommandResult commandResult = logic.execute(commandText);
+            CommandResult commandResult = logic.execute(commandText,
+                    g -> g.equals(CommandGroup.PERSON) || g.equals(CommandGroup.GENERAL));
             logger.info("Result: " + commandResult.getFeedbackToUser());
             resultDisplay.setFeedbackToUser(commandResult.getFeedbackToUser());
 
             if (commandResult.isExit()) {
                 handleExit();
-            }
-
-            if (commandResult.isShowJobList()) {
-                handleListJob();
             }
 
             return commandResult;

--- a/src/main/resources/view/DeliveryJobDetailPane.fxml
+++ b/src/main/resources/view/DeliveryJobDetailPane.fxml
@@ -15,7 +15,7 @@
 <?import javafx.scene.layout.VBox?>
 <?import javafx.scene.text.Font?>
 
-<BorderPane id="detail-pane" prefWidth="500.0" styleClass="background" xmlns="http://javafx.com/javafx/11" xmlns:fx="http://javafx.com/fxml/1">
+<BorderPane id="detail-pane" prefWidth="500.0" styleClass="background" xmlns="http://javafx.com/javafx/19" xmlns:fx="http://javafx.com/fxml/1">
    <center>
       <VBox spacing="10.0">
          <children>
@@ -158,6 +158,11 @@
                            <graphic>
                               <Label graphicTextGap="0.0" styleClass="label-bright" text="🖋" />
                            </graphic></Button>
+                        <Button mnemonicParsing="false" onAction="#handleDeleteAction" text="Delete">
+                           <graphic>
+                              <Label graphicTextGap="0.0" styleClass="label-bright" text="🗑" />
+                           </graphic>
+                        </Button>
                      </children>
                   </HBox>
                </children>


### PR DESCRIPTION
you can now specify what command group are allowed for logic execution by defining a condition.
```java
CommandResult commandResult = logic.execute(commandText,
        g -> g.equals(CommandGroup.PERSON) || g.equals(CommandGroup.GENERAL));
```
refer to `enum CommandGroup`, all command default to general except job and person.

- only general(special: list job), job cmd group available for mainwindow.
- only general, person cmd group available for address book.